### PR TITLE
Add dockerization for local builds

### DIFF
--- a/.eleventyignore
+++ b/.eleventyignore
@@ -3,3 +3,7 @@ LICENSE.md
 README.md
 .github
 config
+Dockerfile
+docker-compose.yaml
+Makefile
+run.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,51 @@
+FROM debian:bookworm
+
+
+RUN apt-get update && apt-get install -y -q --no-install-recommends \
+        apt-transport-https \
+        build-essential \
+        ca-certificates \
+        curl \
+        git \
+        libssl-dev \
+        wget
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Create a script file sourced by both interactive and non-interactive bash shells
+# ENV BASH_ENV /home/user/.bash_env
+# RUN touch "${BASH_ENV}"
+# RUN echo '. "${BASH_ENV}"' >> ~/.bashrc
+
+# update the repository sources list
+# and install dependencies
+RUN apt-get update \
+    && apt-get install -y curl \
+    && apt-get -y autoclean
+
+ENV BASH_ENV $HOME/.bash_env
+RUN touch "${BASH_ENV}"
+RUN echo '. "${BASH_ENV}"' >> ~/.bashrc
+
+# install nvm
+# https://github.com/creationix/nvm#install-script
+RUN curl --silent -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.2/install.sh | PROFILE="${BASH_ENV}" bash
+
+RUN echo node > .nvmrc
+RUN nvm install 22 \
+  && nvm use 22
+
+# confirm installation
+RUN node -v
+RUN npm -v
+
+WORKDIR /app
+COPY . /app
+RUN npm i -g npm@11.1.0 \
+  && npm i -g sass \
+  && npm i -g esbuild \
+  && npm i -g esbuild-sass-plugin
+
+RUN npm install
+RUN npm run build
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+up:
+	docker compose up
+	
+build:
+	docker compose build

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,15 @@
+services:
+  swaf:
+    working_dir: /app
+    build:
+      context: .
+      dockerfile: Dockerfile
+    # restart: always
+    volumes:
+      - ./:/app
+    ports:
+      - 8080:8080
+    expose:
+      - 8080
+    entrypoint: "./run.sh"
+    stdin_open: true

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+pushd /app
+  npm install
+  npm run dev
+popd


### PR DESCRIPTION
Adds

```
make build
```

and

```
make up
```

to allow building and running the site.

Added all relevant files to the ignore, so they do not get published.

## Changes proposed in this pull request:
- Adding a Dockerfile and docker compose for running the site. 
- Adding a Makefile to replace (possibly) longer commands.
- run.sh to bundle commands inside the container at startup.

## security considerations

No security considerations in production.
