### PR TITLE
Updates URL reference for meta tags

### DIFF
--- a/_data/site.yaml
+++ b/_data/site.yaml
@@ -3,7 +3,7 @@ email: wethesongwriters2025@gmail.com
 description: Collaboration between songwriters and federal employees to humanize the people served by the federal government. 
 
 # Used to construct absolute URLs throughout the site
-url: "https://wethesongwriters.org/"
+url: "https://wethesongwriters.org"
 
 #################################################################
 #

--- a/_data/site.yaml
+++ b/_data/site.yaml
@@ -3,7 +3,7 @@ email: wethesongwriters2025@gmail.com
 description: Collaboration between songwriters and federal employees to humanize the people served by the federal government. 
 
 # Used to construct absolute URLs throughout the site
-url: "https://agency-production-url.gov"
+url: "https://wethesongwriters.org/"
 
 #################################################################
 #


### PR DESCRIPTION
## Changes proposed in this pull request:
- Sharing currently doesn't work properly, because the meta tags are populated with the placeholder URL
- Updates the canonical url to populate `meta` tags
-

## security considerations
[Note the any security considerations here, or make note of why there are none]
