### PR TITLE
Removes slug anchor hash after headings when using markdown

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -87,15 +87,8 @@ module.exports = function (config) {
     html: true,
     breaks: true,
     linkify: true,
-  }).use(markdownItAnchor, {
-    permalink: markdownItAnchor.permalink.ariaHidden({
-      placement: 'after',
-      class: 'direct-link',
-      symbol: '#',
-      level: [1, 2, 3, 4],
-    }),
-    slugify: config.getFilter('slug'),
-  });
+  }).use(markdownItAnchor);
+  
   config.setLibrary('md', markdownLibrary);
 
   // Override Browsersync defaults (used only with --serve)

--- a/posts/2025-03-09-refuge.md
+++ b/posts/2025-03-09-refuge.md
@@ -13,7 +13,7 @@ I wrote this song a few years ago, hoping I could stop singing it after a while.
 
 {% include "youtube.html" %}
 
-<h2>Lyrics</h2>
+## Lyrics
 
 **Verse 1**
 D There’s a Cat boat running with the G wind/


### PR DESCRIPTION
## Changes proposed in this pull request:
- Removes config setting that adds `#` after headings when using markdown
- Retains `id` attribute for headings when using markdown (so linking to heading partials still works)
-

## security considerations
[Note the any security considerations here, or make note of why there are none]
